### PR TITLE
Allow empty strings.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,7 +14,7 @@ function getValue (field, callback) {
         timeout: this.timeout,
         json: true
     }, function (error, response, body) {
-        if (!error && response.statusCode === 200 && body.value) {
+        if (!error && response.statusCode === 200 && (body.value || body.value === "")) {
             callback(null, body.value);
         } else {
             if (!error) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,7 +14,7 @@ function getValue (field, callback) {
         timeout: this.timeout,
         json: true
     }, function (error, response, body) {
-        if (!error && response.statusCode === 200 && (body.value || body.value === "")) {
+        if (!error && response.statusCode === 200 && (body.value !== undefined)) {
             callback(null, body.value);
         } else {
             if (!error) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "get-stdin": "^0.1.0",
     "nomnom": "^1.8.0",
-    "request": "2.76.0"
+    "request": "^2.76.0"
   },
   "devDependencies": {
     "mockery": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "get-stdin": "^0.1.0",
     "nomnom": "^1.8.0",
-    "request": "^2.37.0"
+    "request": "2.76.0"
   },
   "devDependencies": {
     "mockery": "^1.4.0",
-    "nock": "^0.42.1",
+    "nock": "^9.0.2",
     "sinon": "^1.10.3",
     "ytestrunner": "^0.3.3",
     "yuitest": "^0.7.9"

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -62,12 +62,12 @@ Y.TestRunner.add(new Y.TestCase({
 
         nock('http://fakeserver/')
             .get('/foo')
-            .delayConnection(500)
+            .socketDelay(500)
             .reply(403, 'Invalid Nonce');
         Assert.isObject(instance);
         instance.get('foo', function (error, value) {
             test.resume(function () {
-                Assert.areEqual('Error: Unable to get value of "foo" - Error: ETIMEDOUT', error.toString());
+                Assert.areEqual('Error: Unable to get value of "foo" - Error: ESOCKETTIMEDOUT', error.toString());
                 Assert.isUndefined(value);
             });
         });
@@ -112,12 +112,12 @@ Y.TestRunner.add(new Y.TestCase({
 
         nock('http://fakeserver/')
             .post('/foo')
-            .delayConnection(500)
+            .socketDelay(500)
             .reply(500, 'Unknown error');
         Assert.isObject(instance);
         instance.set('foo', 'bar', function (error) {
             test.resume(function () {
-                Assert.areEqual('Error: Unable to set value of "foo" - Error: ETIMEDOUT', error);
+                Assert.areEqual('Error: Unable to set value of "foo" - Error: ESOCKETTIMEDOUT', error);
             });
         });
         test.wait(100);

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -39,6 +39,46 @@ Y.TestRunner.add(new Y.TestCase({
         test.wait(100);
     },
 
+    'Can retrieve an empty value': function () {
+        var test = this,
+            instance = new Client('http://fakeserver');
+
+        nock('http://fakeserver/')
+            .get('/foo')
+            .reply(200, {
+                field: 'foo',
+                value: ''
+            });
+        instance.get('foo', function (error, value) {
+            test.resume(function () {
+                Assert.isNull(error);
+                Assert.areEqual('', value);
+            });
+        });
+        test.wait(100);
+    },
+
+    'Can fail to retrieve a missing value': function () {
+        var test = this,
+            instance = new Client('http://fakeserver');
+
+        nock('http://fakeserver/')
+            .get('/something-else')
+            .reply(200, {
+                field: 'something-else',
+                value: undefined
+            });
+        instance.get('something-else', function (error, value) {
+            test.resume(function () {
+
+                Assert.areEqual('Error: Unable to get value of "something-else" - [object Object]',
+                                error.toString());
+                Assert.isUndefined(value);
+            });
+        });
+        test.wait(100);
+    },
+
     'Can fail to retrieve a value': function () {
         var test = this,
             instance = new Client('http://fakeserver/');


### PR DESCRIPTION
Before this change, you get an error if you've explicitly set a value to empty and later try to retrieve it.